### PR TITLE
Deploy the Modbus-REST adapter

### DIFF
--- a/lib/helm.js
+++ b/lib/helm.js
@@ -131,6 +131,13 @@ export async function setup_helm (ss) {
                 authGroup: {
                     edgeAgent:  group.agent.uuid,
         } } }],
+        ["modbus", "Modbus-REST adapter", {
+            chart:  "modbus-rest",
+            values: {
+                name:       "{{name}}",
+                uuid:       "{{uuid}}",
+                hostname:   "{{hostname}}",
+        } }],
     );
 
     return await conf.finish();


### PR DESCRIPTION
Create a Helm Chart Template to allow the Modbus-REST adapter to be deployed alongside an Edge Agent.